### PR TITLE
Implement ContextKernelService and Java 17 config

### DIFF
--- a/contextkernel/build.gradle.kts
+++ b/contextkernel/build.gradle.kts
@@ -11,6 +11,14 @@ android {
         minSdk = 34
         targetSdk = 35
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 }
 
 dependencies {

--- a/contextkernel/src/main/AndroidManifest.xml
+++ b/contextkernel/src/main/AndroidManifest.xml
@@ -2,4 +2,18 @@
 <!-- keep only the manifest tag and the XML namespace -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- we’ll add <application> later if we need it -->
+
+    <permission
+        android:name="com.myco.permission.AI_BIND"
+        android:protectionLevel="signature" />
+
+    <service
+        android:name="com.myco.kernel.ContextKernelService"
+        android:exported="true"
+        android:process=":kernel"
+        android:permission="com.myco.permission.AI_BIND">
+      <intent-filter>
+        <action android:name="com.myco.KERNEL" />
+      </intent-filter>
+    </service>
 </manifest>

--- a/contextkernel/src/main/java/com/myco/kernel/ContextKernelService.kt
+++ b/contextkernel/src/main/java/com/myco/kernel/ContextKernelService.kt
@@ -1,0 +1,32 @@
+package com.myco.kernel
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import android.os.Bundle
+import com.myco.kernel.IContextKernel
+
+class ContextKernelService : Service() {
+    private val binder = object : IContextKernel.Stub() {
+        override fun ask(prompt: String, appId: String, scopes: Bundle): String {
+            TODO("Implement LLM inference")
+        }
+        override fun putSecret(label: String, data: ByteArray): ByteArray {
+            TODO("Implement secure vault write")
+        }
+        override fun getSecret(label: String): ByteArray {
+            TODO("Implement secure vault read")
+        }
+        override fun addVector(ns: String, embedding: FloatArray, jsonMeta: String) {
+            TODO("Implement vector store add")
+        }
+        override fun search(ns: String, query: FloatArray, k: Int): MutableList<VectorHit> {
+            TODO("Implement vector store search")
+        }
+        override fun fireIntent(action: String, extras: Bundle) {
+            TODO("Implement structured or fallback automation")
+        }
+    }
+
+    override fun onBind(intent: Intent): IBinder = binder
+}

--- a/contextkernel/src/test/java/com/myco/kernel/ContextKernelServiceTest.kt
+++ b/contextkernel/src/test/java/com/myco/kernel/ContextKernelServiceTest.kt
@@ -1,0 +1,20 @@
+package com.myco.kernel
+
+import android.content.Intent
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class ContextKernelServiceTest {
+  private lateinit var service: ContextKernelService
+
+  @Before fun setup() {
+    service = ContextKernelService()
+  }
+
+  @Test fun bindReturnsNonNullBinder() {
+    val binder = service.onBind(Intent("com.myco.KERNEL"))
+    assertNotNull("Binder should not be null", binder)
+    assertTrue("Binder must implement IContextKernel", binder is IContextKernel)
+  }
+}

--- a/sampleapp/build.gradle.kts
+++ b/sampleapp/build.gradle.kts
@@ -14,6 +14,14 @@ android {
         versionCode = 1
         versionName = "1.0"
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- add service stub `ContextKernelService`
- register the service and permission in the manifest
- create unit tests ensuring binder returned
- enable Java 17 source/target options for modules

## Testing
- `sh ./gradlew :contextkernel:test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f8f60f084833287fd78f23ace2a9b