### PR TITLE
Fix AIDL configuration in contextkernel

### DIFF
--- a/contextkernel/build.gradle.kts
+++ b/contextkernel/build.gradle.kts
@@ -19,6 +19,12 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+
+    sourceSets {
+        getByName("main") {
+            aidl.srcDirs("src/main/aidl")
+        }
+    }
 }
 
 dependencies {

--- a/contextkernel/src/main/aidl/com/myco/kernel/VectorHit.aidl
+++ b/contextkernel/src/main/aidl/com/myco/kernel/VectorHit.aidl
@@ -1,0 +1,3 @@
+package com.myco.kernel;
+
+parcelable VectorHit;


### PR DESCRIPTION
## Summary
- configure `contextkernel` to include `src/main/aidl` in its `sourceSets`
- add missing `VectorHit` parcelable declaration

## Testing
- `./gradlew tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_686fa71382c883329b544f31e3d8e793