### PR TITLE
Add AIDL VectorHit

### DIFF
--- a/contextkernel/build.gradle.kts
+++ b/contextkernel/build.gradle.kts
@@ -11,6 +11,12 @@ android {
         minSdk = 34
         targetSdk = 35
     }
+
+    sourceSets {
+        getByName("main") {
+            aidl.srcDirs("src/main/aidl")
+        }
+    }
 }
 
 dependencies {

--- a/contextkernel/src/main/aidl/com/myco/kernel/VectorHit.aidl
+++ b/contextkernel/src/main/aidl/com/myco/kernel/VectorHit.aidl
@@ -1,0 +1,2 @@
+package com.myco.kernel;
+parcelable VectorHit;


### PR DESCRIPTION
## Summary
- enable AIDL compilation in `contextkernel`
- add missing `VectorHit` parcelable stub

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa9d6e7348332a2c4787dc2004004